### PR TITLE
SIMULAP/simulap-support/issues/67

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,8 +34,13 @@
 		<maven.dependency.plugin>3.1.1</maven.dependency.plugin>
 		<maven.surefire.plugin>2.22.2</maven.surefire.plugin>
 
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<requireMavenVersion>3.6.3</requireMavenVersion>
+		<maven.enforcer.plugin>3.0.0-M3</maven.enforcer.plugin>
+		<maven.compiler.plugin>3.8.1</maven.compiler.plugin>
+
+		<jdk.version>11</jdk.version>
+		<maven.compiler.release>${jdk.version}</maven.compiler.release>
+
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<plugin.version>0.0</plugin.version>
@@ -47,30 +52,8 @@
 		<junit.version>4.12</junit.version>
 		<slf4j.version>1.7.30</slf4j.version>
 		<jetty.version>9.4.28.v20200408</jetty.version>
-		<alpn-boot.version>8.1.13.v20181017</alpn-boot.version>
 		<alpn-api.version>1.1.3.v20160715</alpn-api.version>
 	</properties>
-
-	<profiles>
-		<profile>
-			<id>java-1.8</id>
-			<activation>
-				<jdk>[1.8.0,1.8.0_252)</jdk>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<version>${maven.surefire.plugin}</version>
-						<configuration>
-							<argLine>-Xbootclasspath/p:${project.build.directory}/dependencies/alpn-boot-${alpn-boot.version}.jar</argLine>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
 
 	<build>
 		<pluginManagement>
@@ -94,6 +77,31 @@
 		</pluginManagement>
 
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>${maven.enforcer.plugin}</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>${requireMavenVersion}</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>${maven.compiler.plugin}</version>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
@@ -200,14 +208,6 @@
 						<artifactItem>
 							<groupId>org.eclipse.jetty</groupId>
 							<artifactId>jetty-util</artifactId>
-							<version>${jetty.version}</version>
-							<type>jar</type>
-							<overWrite>false</overWrite>
-							<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
-						</artifactItem>
-						<artifactItem>
-							<groupId>org.eclipse.jetty</groupId>
-							<artifactId>jetty-alpn-openjdk8-client</artifactId>
 							<version>${jetty.version}</version>
 							<type>jar</type>
 							<overWrite>false</overWrite>
@@ -328,16 +328,6 @@
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-util</artifactId>
 			<version>${jetty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-alpn-openjdk8-client</artifactId>
-			<version>${jetty.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.mortbay.jetty.alpn</groupId>
-			<artifactId>alpn-boot</artifactId>
-			<version>${alpn-boot.version}</version>
 		</dependency>
 		<!-- test -->
 		<dependency>


### PR DESCRIPTION
1. Java source and runtime version set to JDK11
2. Apache Jmeter version set to 5.1.1
3. Minimum Maven version set
4. Removed dependency: alpn-boot
5. Replaced dependency: ‘jetty-alpn-openjdk8-client’ with ‘jetty-alpn-java-client’ for Java 11