### PR TITLE
Fix for issue #239

### DIFF
--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Request.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/HTTP2Request.java
@@ -129,11 +129,10 @@ public class HTTP2Request extends AbstractSampler implements ThreadListener, Loo
     private HTTP2Connection http2Connection;
 
     public HTTP2Request() {
-        if (LOG.isDebugEnabled()) {
-            StdErrLog logger = new StdErrLog();
-            logger.setDebugEnabled(true);
-            Log.setLog(logger);
-        }
+		/*
+		 * if (LOG.isDebugEnabled()) { StdErrLog logger = new StdErrLog();
+		 * logger.setDebugEnabled(true); Log.setLog(logger); }
+		 */
         setName("HTTP2 Request");
     }
 

--- a/src/main/java/com/blazemeter/jmeter/http2/sampler/RequestBody.java
+++ b/src/main/java/com/blazemeter/jmeter/http2/sampler/RequestBody.java
@@ -29,6 +29,10 @@ public class RequestBody {
 
     public static RequestBody from(String method, String contentEncoding, Arguments args, boolean sendParamsAsBody)
             throws UnsupportedEncodingException {
+    	if(args.toString().equals("=()")) {
+    		args.clear();
+    		LOG.debug("Content of args is "+args);
+    	} 
         switch(method) {
             case HTTPConstants.GET:
                 return new RequestBody(buildGetRequest(contentEncoding, args), contentEncoding);


### PR DESCRIPTION
When bodyData tab is chosen as default option and  is empty , extra characters are passed to backend.